### PR TITLE
better error message on Error(string) starts with "AA"

### DIFF
--- a/packages/bundler/src/modules/ValidationManager.ts
+++ b/packages/bundler/src/modules/ValidationManager.ts
@@ -150,12 +150,14 @@ export class ValidationManager {
       return [errorResult, tracerResult]
     } catch (e: any) {
       // if already parsed, throw as is
+      console.log("AAAA");
       if (e.code !== "INVALID_ARGUMENT" && e.code != null) {
         throw e
       }
       // not a known error of EntryPoint (probably, only Error(string), since FailedOp is handled above)
       const err = decodeErrorReason(data)
-      throw new RpcError(err != null ? err.message : data, 111)
+      const errCode = err && err.message.startsWith("AA") ? -32500 : 111
+      throw new RpcError(err != null ? err.message : data, errCode)
     }
   }
 


### PR DESCRIPTION
bundler reverted with `{"jsonrpc":"2.0","id":"1","error":{"message":"no matching error (argument=\"sighash\", value=\"0x08c379a0\", code=INVALID_ARGUMENT, version=abi/5.7.0)","code":"INVALID_ARGUMENT"}}` when entrypoint reverted with `require()` not `FailedOp()`,
it is fixed on main branch but it still returns error code `111` which is quite strange imo.
so i have added a fix to return -32501 when revert reason starts with "AA"